### PR TITLE
Components sub-branch has been added and the MaterialInput component

### DIFF
--- a/src/MaterialInput.js
+++ b/src/MaterialInput.js
@@ -8,4 +8,4 @@ class MaterialInput extends React.Component {
     );
   }
 }
-export default Fancy;
+export default MaterialInput;

--- a/src/MaterialInput.js
+++ b/src/MaterialInput.js
@@ -1,0 +1,11 @@
+import React from 'react';
+class MaterialInput extends React.Component {
+  render() {
+    return (
+      <div>
+        <input placeholder="Material input" type="text"/>
+      </div>
+    );
+  }
+}
+export default Fancy;

--- a/src/index.js
+++ b/src/index.js
@@ -1,9 +1,3 @@
-import React from 'react';
-class Fancy extends React.Component {
-  render() {
-    return (
-      <div>This is so Fancy!</div>
-    );
-  }
-}
-export default Fancy;
+import MaterialInput from './components/MaterialInput';
+
+export {MaterialInput}


### PR DESCRIPTION
The project structure has been modified index.js now exports all components from our components folder and makes them available in a single import.

Example: 

`import {MaterialInput} from 'creative-react'` 

some other components could easily be imported.

Example:

`import {MaterialInput, AnotherComponent} from 'creative-react'` 